### PR TITLE
Hubspot hooks for Captain Hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Create local configuration file `hooks/settings_local.py`.
 *  `/api/v1/{scope}/fb/hooks`
 	* *scope* is one of master, staging or testing
 
+*  `/api/v1/hubspot/hooks`
+	* not scoped, as Hubspot doesn't have a staging version
+
 *  `/api/v1/proxy/{url}`
 	* *url* can be any url, e.g. http://www.google.com
 


### PR DESCRIPTION
Turns out Python isn't that bad language after all.
Seriously - this should do one thing - forward HS webhooks into the same exchange as other ROIH hooks, but into a different queue - that will be declared on ROI Hunter side (should already be setup on staging rabbit).

I believe on_get is not necessary, as Hubspot doesn't have any challenge (or at least I don't know about any). Other than that it's pretty much CP.

@martinvy please take a look :eye: Thanks