### PR TITLE
Special header for Hubspot messages

### DIFF
--- a/hooks/api_server.py
+++ b/hooks/api_server.py
@@ -57,7 +57,7 @@ class HubspotHooks:
 
         try:
             with self._publisher as publisher:
-                publisher.send_event('hubspot', payload)
+                publisher.send_hubspot_event(payload)
 
             resp.status = falcon.HTTP_200
         except pika.exceptions.AMQPError:

--- a/hooks/publisher.py
+++ b/hooks/publisher.py
@@ -37,3 +37,16 @@ class RabbitPublisher:
                 delivery_mode=self.PERSISTENT_MESSAGE_FLAG
             )
         )
+
+    def send_hubspot_event(self, json_data):
+        self._channel.basic_publish(
+            exchange=self._exchange_name,
+            routing_key="hubspot",
+            body=json_data,
+            properties=pika.BasicProperties(
+                headers={"__TypeId__": "HubspotEventMessage"},
+                content_encoding="utf-8",
+                content_type="application/json",
+                delivery_mode=self.PERSISTENT_MESSAGE_FLAG
+            )
+        )


### PR DESCRIPTION
Turns out I missed the header on Hook side that forces all messages to behave like they came from Facebook. Hubspot needs special treatment.

@martinvy please take a look :eye: Thanks