### PR TITLE
Increase Gunicorn worker eventlet connections, 10 -> 100.

### DIFF
--- a/hooks/settings/settings_gunicorn.py
+++ b/hooks/settings/settings_gunicorn.py
@@ -12,7 +12,7 @@ import os
 workers = 4
 bind = "0.0.0.0:8005"
 worker_class = "eventlet"
-worker_connections = 10
+worker_connections = 100
 
 # Overwrite some Gunicorns params by ENV variables
 for k, v in os.environ.items():


### PR DESCRIPTION
I think it's better than before. Let's set up even more connections. By the way the default value is 1000.

@business-factory/pythonistas please review & merge.