### PR TITLE
Log only to GL on production & use requests patched by eventlet

### DIFF
--- a/hooks/api_server.py
+++ b/hooks/api_server.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
+import eventlet
 import falcon
 import pika.exceptions
-import requests
 
 from . import services, settings
 
@@ -119,3 +119,6 @@ class API(falcon.API):
         self.add_route(_API_PREFIX + "/{scope}/fb/hooks", FacebookHooks())
         self.add_route(_API_PREFIX + "/hubspot/hooks", HubspotHooks())
         self.add_route(_API_PREFIX + "/proxy", CorsProxy())
+
+        global requests
+        requests = eventlet.import_patched("requests")

--- a/hooks/services.py
+++ b/hooks/services.py
@@ -16,16 +16,16 @@ def logger():
     for handler in logging.root.handlers:
         handler.addFilter(logging.Filter("hooks"))
 
-    handler = logging.StreamHandler()
-    handler.setFormatter(logging.Formatter(
-        "[%(levelname)s] %(asctime)s at %(filename)s:%(lineno)d (%(processName)s) -- %(message)s",
-        "%Y-%m-%d %H:%M:%S")
-    )
-    logger.addHandler(handler)
-
     if not settings.DEVELOPMENT_MODE:
         handler = graypy.GELFHandler(settings.GRAYLOG_HOST, settings.GRAYLOG_PORT)
-        logger.addHandler(handler)
+    else:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter(
+            "[%(levelname)s] %(asctime)s at %(filename)s:%(lineno)d (%(processName)s) -- %(message)s",
+            "%Y-%m-%d %H:%M:%S")
+        )
+
+    logger.addHandler(handler)
 
     return logger
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+eventlet==0.24.1
 falcon==1.4.1
 graypy==0.2.14
 gunicorn[eventlet]==19.9.0


### PR DESCRIPTION
https://stackoverflow.com/questions/28315657/celery-eventlet-non-blocking-requests

Finally, the API seems to have much bigger throughput now. Without the patch, eventlet was not really useful in context of CORS proxy.

@business-factory/pythonistas please review & merge.